### PR TITLE
Team: add endpoints to manage package access

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,26 @@ $teams = $client->teams()->all();
 ```
 Returns an array of teams.
 
+##### List all private packages a team has access to
+```php
+$teamId = 1;
+$packages = $client->teams()->packages($teamId);
+```
+Returns an array of packages.
+
+##### Grant a team access to a list of private packages
+```php
+$teamId = 1;
+$packages = $client->teams()->addPackages($teamId, ['acme-website/package']);
+```
+Returns an array of packages.
+
+##### Remove access for a package from a team
+```php
+$teamId = 1;
+$packages = $client->teams()->removePackage($teamId, 'acme-website/package');
+```
+
 #### Customer
 
 ##### List an organization's customers

--- a/src/Api/Teams.php
+++ b/src/Api/Teams.php
@@ -15,4 +15,19 @@ class Teams extends AbstractApi
     {
         return $this->get('/teams/');
     }
+
+    public function packages($teamId)
+    {
+        return $this->get(sprintf('/teams/%s/packages/', $teamId));
+    }
+
+    public function addPackages($teamId, array $packages)
+    {
+        return $this->post(sprintf('/teams/%s/packages/', $teamId), $packages);
+    }
+
+    public function removePackage($teamId, $packageName)
+    {
+        return $this->delete(sprintf('/teams/%s/packages/%s/', $teamId, $packageName));
+    }
 }

--- a/tests/Api/TeamsTest.php
+++ b/tests/Api/TeamsTest.php
@@ -39,6 +39,58 @@ class TeamsTest extends ApiTestCase
         $this->assertSame($expected, $api->all());
     }
 
+    public function testPackages()
+    {
+        $expected = [
+            [
+                'id' => 1,
+                'name' => 'acme-website/package',
+            ],
+        ];
+
+        /** @var Teams&\PHPUnit_Framework_MockObject_MockObject $api */
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('/teams/1/packages/'))
+            ->willReturn($expected);
+
+        $this->assertSame($expected, $api->packages(1));
+    }
+
+    public function testAddPackages()
+    {
+        $expected = [
+            [
+                'id' => 1,
+                'name' => 'acme-website/package',
+            ],
+        ];
+
+        /** @var Teams&\PHPUnit_Framework_MockObject_MockObject $api */
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with($this->equalTo('/teams/1/packages/'), $this->equalTo(['acme-website/package']))
+            ->willReturn($expected);
+
+        $this->assertSame($expected, $api->addPackages(1, ['acme-website/package']));
+    }
+
+    public function testRemovePackage()
+    {
+        $expected = [];
+
+        /** @var Teams&\PHPUnit_Framework_MockObject_MockObject $api */
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with($this->equalTo('/teams/1/packages/acme-website/package/'))
+            ->willReturn($expected);
+
+        $this->assertSame($expected, $api->removePackage(1, 'acme-website/package'));
+    }
+
     /**
      * @return string
      */


### PR DESCRIPTION
Adds endpoints to:
* list all private packages a team has access to
* grant a team access to a list of private packages
* revoke access to a package for a team