### PR TITLE
Fix passing null to parameter of type string

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -18,6 +18,7 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
+          - "8.1"
 
     steps:
       - uses: actions/checkout@v2

--- a/src/HttpClient/Plugin/RequestSignature.php
+++ b/src/HttpClient/Plugin/RequestSignature.php
@@ -84,6 +84,6 @@ class RequestSignature implements Plugin
     {
         uksort($params, 'strcmp');
 
-        return http_build_query($params, null, '&', PHP_QUERY_RFC3986);
+        return http_build_query($params, '', '&', PHP_QUERY_RFC3986);
     }
 }

--- a/src/WebhookSignature.php
+++ b/src/WebhookSignature.php
@@ -19,7 +19,7 @@ class WebhookSignature
      */
     public function validate($signature, $payload)
     {
-        $payloadSignature = 'sha1='.hash_hmac('sha1', $payload, $this->secret);
+        $payloadSignature = 'sha1='.hash_hmac('sha1', $payload ?? '', $this->secret);
 
         return hash_equals($payloadSignature, (string) $signature);
     }

--- a/src/WebhookSignature.php
+++ b/src/WebhookSignature.php
@@ -14,7 +14,7 @@ class WebhookSignature
 
     /**
      * @param string $signature
-     * @param string $payload
+     * @param ?string $payload
      * @return bool
      */
     public function validate($signature, $payload)


### PR DESCRIPTION
Passing `null` to internal PHP functions, with argument type of string
is deprecated in PHP 8.1.

This can be easily fixed by supplying empty strings instead.

Closes #47 