### PR TITLE
Upgrade HTTPlug from Legacy to PSR 17/18 Discovery Factories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,13 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "ext-json": "*",
+        "composer-runtime-api": "^2.0",
         "php-http/client-common": "^1.9 || ^2.0",
         "php-http/discovery": "^1.0",
         "psr/http-client-implementation": "^1.0",
         "php-http/message-factory": "^1.0",
         "psr/http-message-implementation": "^1.0",
-        "composer-runtime-api": "^2.0"
+        "symfony/deprecation-contracts": "^2.5 || ^3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -12,20 +12,20 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "psr/http-message": "^1.0",
-        "php-http/httplug": "^1.1 || ^2.0",
+        "ext-json": "*",
+        "php-http/client-common": "^1.9 || ^2.0",
         "php-http/discovery": "^1.0",
         "psr/http-client-implementation": "^1.0",
-        "php-http/client-common": "^1.9 || ^2.0",
         "php-http/message-factory": "^1.0",
+        "psr/http-message-implementation": "^1.0",
         "composer-runtime-api": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0 || ^9.0",
-        "guzzlehttp/guzzle": "^7",
-        "php-http/mock-client": "^1.0",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "phpstan/phpstan": "^1.2"
+        "php-http/guzzle7-adapter": "^1.0",
+        "php-http/mock-client": "^1.0",
+        "phpstan/phpstan": "^1.2",
+        "phpunit/phpunit": "^8.0 || ^9.0"
     },
     "autoload": {
         "psr-4": { "PrivatePackagist\\ApiClient\\": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
-        "php-http/guzzle7-adapter": "^1.0",
+        "guzzlehttp/guzzle": "^7.0",
         "php-http/mock-client": "^1.0",
         "phpstan/phpstan": "^1.2",
         "phpunit/phpunit": "^8.0 || ^9.0"

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
         "php-http/discovery": "^1.0",
         "psr/http-client-implementation": "^1.0",
         "php-http/message-factory": "^1.0",
-        "psr/http-message-implementation": "^1.0",
-        "symfony/deprecation-contracts": "^2.5 || ^3.0"
+        "psr/http-message-implementation": "^1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",

--- a/src/Client.php
+++ b/src/Client.php
@@ -10,7 +10,7 @@
 namespace PrivatePackagist\ApiClient;
 
 use Http\Client\Common\Plugin;
-use Http\Discovery\UriFactoryDiscovery;
+use Http\Discovery\Psr17FactoryDiscovery;
 use PrivatePackagist\ApiClient\HttpClient\HttpPluginClientBuilder;
 use PrivatePackagist\ApiClient\HttpClient\Message\ResponseMediator;
 use PrivatePackagist\ApiClient\HttpClient\Plugin\ExceptionThrower;
@@ -31,7 +31,7 @@ class Client
         $privatePackagistUrl = $privatePackagistUrl ? : 'https://packagist.com';
         $this->responseMediator = $responseMediator ? : new ResponseMediator();
 
-        $builder->addPlugin(new Plugin\AddHostPlugin(UriFactoryDiscovery::find()->createUri($privatePackagistUrl)));
+        $builder->addPlugin(new Plugin\AddHostPlugin(Psr17FactoryDiscovery::findUriFactory()->createUri($privatePackagistUrl)));
         $builder->addPlugin(new PathPrepend('/api'));
         $builder->addPlugin(new Plugin\RedirectPlugin());
         $headers = [

--- a/src/HttpClient/HttpPluginClientBuilder.php
+++ b/src/HttpClient/HttpPluginClientBuilder.php
@@ -17,6 +17,7 @@ use Http\Discovery\Psr18ClientDiscovery;
 use Http\Message\RequestFactory;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 
 class HttpPluginClientBuilder
 {
@@ -26,14 +27,19 @@ class HttpPluginClientBuilder
     private $pluginClient;
     /** @var RequestFactory|RequestFactoryInterface */
     private $requestFactory;
+    private $streamFactory;
     /** @var Plugin[] */
     private $plugins = [];
 
     /**
      * @param RequestFactory|RequestFactoryInterface|null $requestFactory
+     * @param StreamFactoryInterface|null $streamFactory
      */
-    public function __construct(?ClientInterface $httpClient = null, $requestFactory = null)
-    {
+    public function __construct(
+        ?ClientInterface $httpClient = null,
+        $requestFactory = null,
+        ?StreamFactoryInterface $streamFactory= null
+    ) {
         $requestFactory = $requestFactory ?? Psr17FactoryDiscovery::findRequestFactory();
         if ($requestFactory instanceof RequestFactory) {
             // Use same format as symfony/deprecation-contracts.
@@ -57,6 +63,7 @@ class HttpPluginClientBuilder
 
         $this->httpClient = $httpClient ?? Psr18ClientDiscovery::find();
         $this->requestFactory = $requestFactory;
+        $this->streamFactory = $streamFactory ?? Psr17FactoryDiscovery::findStreamFactory();
     }
 
     public function addPlugin(Plugin $plugin)
@@ -83,7 +90,8 @@ class HttpPluginClientBuilder
         if (!$this->pluginClient) {
             $this->pluginClient = new HttpMethodsClient(
                 new PluginClient($this->httpClient, $this->plugins),
-                $this->requestFactory
+                $this->requestFactory,
+                $this->streamFactory
             );
         }
 

--- a/src/HttpClient/HttpPluginClientBuilder.php
+++ b/src/HttpClient/HttpPluginClientBuilder.php
@@ -27,6 +27,7 @@ class HttpPluginClientBuilder
     private $pluginClient;
     /** @var RequestFactory|RequestFactoryInterface */
     private $requestFactory;
+    /** @var StreamFactoryInterface */
     private $streamFactory;
     /** @var Plugin[] */
     private $plugins = [];
@@ -73,7 +74,7 @@ class HttpPluginClientBuilder
     }
 
     /**
-     * @param string $pluginClass
+     * @param class-string $pluginClass
      */
     public function removePlugin($pluginClass)
     {

--- a/src/HttpClient/HttpPluginClientBuilder.php
+++ b/src/HttpClient/HttpPluginClientBuilder.php
@@ -12,10 +12,10 @@ namespace PrivatePackagist\ApiClient\HttpClient;
 use Http\Client\Common\HttpMethodsClient;
 use Http\Client\Common\Plugin;
 use Http\Client\Common\PluginClient;
-use Http\Discovery\HttpClientDiscovery;
-use Http\Discovery\MessageFactoryDiscovery;
-use Http\Message\RequestFactory;
+use Http\Discovery\Psr17FactoryDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 
 class HttpPluginClientBuilder
 {
@@ -23,15 +23,15 @@ class HttpPluginClientBuilder
     private $httpClient;
     /** @var HttpMethodsClient|null */
     private $pluginClient;
-    /** @var RequestFactory */
+    /** @var RequestFactoryInterface */
     private $requestFactory;
     /** @var Plugin[] */
     private $plugins = [];
 
-    public function __construct(ClientInterface $httpClient = null, RequestFactory $requestFactory = null)
+    public function __construct(ClientInterface $httpClient = null, RequestFactoryInterface $requestFactory = null)
     {
-        $this->httpClient = $httpClient ?: HttpClientDiscovery::find();
-        $this->requestFactory = $requestFactory ?: MessageFactoryDiscovery::find();
+        $this->httpClient = $httpClient ?: Psr18ClientDiscovery::find();
+        $this->requestFactory = $requestFactory ?: Psr17FactoryDiscovery::findRequestFactory();
     }
 
     public function addPlugin(Plugin $plugin)

--- a/src/HttpClient/HttpPluginClientBuilder.php
+++ b/src/HttpClient/HttpPluginClientBuilder.php
@@ -34,7 +34,7 @@ class HttpPluginClientBuilder
      */
     public function __construct(?ClientInterface $httpClient = null, $requestFactory = null)
     {
-        $requestFactory = $requestFactory ?: Psr17FactoryDiscovery::findRequestFactory();
+        $requestFactory = $requestFactory ?? Psr17FactoryDiscovery::findRequestFactory();
         if ($requestFactory instanceof RequestFactory) {
             // Use same format as symfony/deprecation-contracts.
             @trigger_error(sprintf(
@@ -55,7 +55,7 @@ class HttpPluginClientBuilder
             ));
         }
 
-        $this->httpClient = $httpClient ?: Psr18ClientDiscovery::find();
+        $this->httpClient = $httpClient ?? Psr18ClientDiscovery::find();
         $this->requestFactory = $requestFactory;
     }
 

--- a/src/HttpClient/HttpPluginClientBuilder.php
+++ b/src/HttpClient/HttpPluginClientBuilder.php
@@ -24,7 +24,7 @@ class HttpPluginClientBuilder
     private $httpClient;
     /** @var HttpMethodsClient|null */
     private $pluginClient;
-    /** @var RequestFactoryInterface */
+    /** @var RequestFactory|RequestFactoryInterface */
     private $requestFactory;
     /** @var Plugin[] */
     private $plugins = [];

--- a/src/HttpClient/HttpPluginClientBuilder.php
+++ b/src/HttpClient/HttpPluginClientBuilder.php
@@ -40,7 +40,7 @@ class HttpPluginClientBuilder
             @trigger_error(sprintf(
                 'Since %s %s: %s is deprecated, use %s instead.',
                 'private-packagist/api-client',
-                '1.35.0',
+                '1.36.0',
                 RequestFactory::class,
                 RequestFactoryInterface::class
             ), \E_USER_DEPRECATED);

--- a/src/HttpClient/HttpPluginClientBuilder.php
+++ b/src/HttpClient/HttpPluginClientBuilder.php
@@ -30,21 +30,22 @@ class HttpPluginClientBuilder
     private $plugins = [];
 
     /**
-     * @param ClientInterface|null $httpClient
      * @param RequestFactory|RequestFactoryInterface|null $requestFactory
      */
-    public function __construct(ClientInterface $httpClient = null, $requestFactory = null)
+    public function __construct(?ClientInterface $httpClient = null, $requestFactory = null)
     {
         $requestFactory = $requestFactory ?: Psr17FactoryDiscovery::findRequestFactory();
         if ($requestFactory instanceof RequestFactory) {
-            trigger_deprecation(
+            // Use same format as symfony/deprecation-contracts.
+            @trigger_error(sprintf(
+                'Since %s %s: %s is deprecated, use %s instead.',
                 'private-packagist/api-client',
                 '1.35.0',
-                '',
                 RequestFactory::class,
                 RequestFactoryInterface::class
-            );
+            ), \E_USER_DEPRECATED);
         } elseif (!$requestFactory instanceof RequestFactoryInterface) {
+            /** @var mixed $requestFactory value unknown; set to mixed, prevent PHPStan complaining about guard clauses */
             throw new \TypeError(sprintf(
                 '%s::__construct(): Argument #2 ($requestFactory) must be of type %s|%s, %s given',
                 self::class,

--- a/tests/HttpClient/HttpPluginClientBuilderTest.php
+++ b/tests/HttpClient/HttpPluginClientBuilderTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * (c) Packagist Conductors GmbH <contact@packagist.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PrivatePackagist\ApiClient\HttpClient\Plugin;
+
+use GuzzleHttp\Psr7\HttpFactory;
+use GuzzleHttp\Psr7\Response;
+use Http\Client\Common\HttpMethodsClientInterface;
+use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Http\Message\RequestMatcher as RequestMatcherInterface;
+use Http\Mock\Client as MockClient;
+use PHPUnit\Framework\TestCase;
+use PrivatePackagist\ApiClient\HttpClient\HttpPluginClientBuilder;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class HttpPluginClientBuilderTest extends TestCase
+{
+    /** @dataProvider provideRequestFactories */
+    public function testRequestFactory(?object $factory, ?string $expectedException): void
+    {
+        if ($expectedException !== null) {
+            $this->expectException($expectedException);
+        }
+
+        $mockHttp = new MockClient;
+        $mockHttp->setDefaultException(new \Exception('Mock HTTP client did not match request.'));
+        $mockHttp->on($this->matchRequestIncludingHeaders(), new Response(307, ['Location' => '/kittens.jpg']));
+
+        $builder = new HttpPluginClientBuilder($mockHttp, $factory);
+        // Make sure that the RequestFactory passed is acceptable for the client.
+        $client = $builder->getHttpClient();
+        $this->assertInstanceOf(HttpMethodsClientInterface::class, $client);
+
+        // Ensure that the Request Factory correctly generates a request object (including headers
+        // as RequestFactory and RequestFactoryInterface set headers differently).
+        $response = $client->get('https://example.com/puppies.jpg', ['Accept' => 'image/vnd.cute+jpeg']);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertSame(307, $response->getStatusCode());
+        $locationHeaders = $response->getHeader('Location');
+        $this->assertCount(1, $locationHeaders);
+        $this->assertSame('/kittens.jpg', reset($locationHeaders));
+    }
+
+    /**
+     * The concrete implementation of the RequestMatcher interface does not allow matching on
+     * headers, which we need to test to ensure both legacy and PSR17 implementations work.
+     */
+    protected function matchRequestIncludingHeaders(): RequestMatcherInterface
+    {
+        return new class implements RequestMatcherInterface {
+            public function matches(RequestInterface $request): bool
+            {
+                $acceptHeaders = $request->getHeader('Accept');
+                return $request->getUri()->getPath() === '/puppies.jpg'
+                    && count($acceptHeaders) === 1
+                    && reset($acceptHeaders) === 'image/vnd.cute+jpeg';
+            }
+        };
+    }
+
+    /** @return iterable{object|null, class-string|null} */
+    private static function provideRequestFactories(): iterable
+    {
+        // Fallback
+        yield [null, null];
+        // Legacy
+        yield [new GuzzleMessageFactory, null];
+        // PSR17
+        yield [new HttpFactory, null];
+        // Invalid
+        yield [new \stdClass, \TypeError::class];
+    }
+}

--- a/tests/HttpClient/HttpPluginClientBuilderTest.php
+++ b/tests/HttpClient/HttpPluginClientBuilderTest.php
@@ -26,6 +26,7 @@ class HttpPluginClientBuilderTest extends TestCase
     {
         $this->expectException(\TypeError::class);
         $definitelyNotARequestFactory = new \stdClass;
+        /** @phpstan-ignore-next-line We are passing in an invalid type on purpose. */
         new HttpPluginClientBuilder(new MockClient, $definitelyNotARequestFactory);
     }
 
@@ -72,7 +73,9 @@ class HttpPluginClientBuilderTest extends TestCase
     public static function provideRequestFactories(): iterable
     {
         yield [null];
+        // Http\Message\RequestFactory
         yield [new GuzzleMessageFactory];
+        // Psr\Http\Message\RequestFactoryInterface
         yield [new HttpFactory];
     }
 }

--- a/tests/HttpClient/HttpPluginClientBuilderTest.php
+++ b/tests/HttpClient/HttpPluginClientBuilderTest.php
@@ -66,7 +66,7 @@ class HttpPluginClientBuilderTest extends TestCase
     }
 
     /** @return iterable{object|null, class-string|null} */
-    private static function provideRequestFactories(): iterable
+    public static function provideRequestFactories(): iterable
     {
         // Fallback
         yield [null, null];


### PR DESCRIPTION
**Note:** Have yet to check lowest supported PHP version for this. Will just check result of CI.

# Tested With

<details>
<summary>composer.json</summary>

```json
{
    "name": "acme/sdk-test",
    "minimum-stability": "dev",
    "require": {
        "private-packagist/api-client": "*",
        "php-http/guzzle7-adapter": "^1.0"
    },
    "repositories": [
        {
            "type": "path",
            "url": "../packagist-client",
            "options": {
                "symlink": true
            }
        }
    ],
    "config": {
        "allow-plugins": {
            "php-http/discovery": true
        }
    }
}
```

</details>

<details>
<summary>index.php</summary>

```php
<?php declare(strict_types=1);

require_once __DIR__ . '/vendor/autoload.php';

$client = new \PrivatePackagist\ApiClient\Client(null, 'http://packagist.com.lo');
$client->authenticate('7280a1da6c486c87a99d', '6469742...9be53aa5f7b');

$teamNames = array_map(fn (array $team): string => $team['name'] ?? '', $client->teams()->all());
var_dump($teamNames);
```

</details>