### PR TITLE
Mention subrepository package id changes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,9 +614,15 @@ $packages = $client->subrepositories()->packages()->all($subrepositoryName);
 Returns an array of subrepositories packages.
 
 #### Show a subrepository package
+
+You can reference a package by its name or ID.
+
 ```php
 $subrepositoryName = 'subrepository';
+// Either use package name:
 $package = $client->subrepositories()->packages()->show($subrepositoryName, 'acme-website/package');
+// Or the package ID: 
+$package = $client->subrepositories()->packages()->show($subrepositoryName, 123);
 ```
 Returns the package.
 

--- a/src/Api/Subrepositories/Packages.php
+++ b/src/Api/Subrepositories/Packages.php
@@ -25,9 +25,9 @@ class Packages extends AbstractApi
         return $this->get(sprintf('/subrepositories/%s/packages/', $subrepositoryName), $filters);
     }
 
-    public function show($subrepositoryName, $packageName)
+    public function show($subrepositoryName, $packageIdOrName)
     {
-        return $this->get(sprintf('/subrepositories/%s/packages/%s', $subrepositoryName, $packageName));
+        return $this->get(sprintf('/subrepositories/%s/packages/%s', $subrepositoryName, $packageIdOrName));
     }
 
     public function createVcsPackage($subrepositoryName, $url, $credentialId = null, $type = 'vcs', $defaultSubrepositoryAccess = null)
@@ -44,27 +44,27 @@ class Packages extends AbstractApi
         return $this->post(sprintf('/subrepositories/%s/packages/', $subrepositoryName), $data->toParameters());
     }
 
-    public function editVcsPackage($subrepositoryName, $packageName, $url, $credentialId = null, $type = 'vcs', $defaultSubrepositoryAccess = null)
+    public function editVcsPackage($subrepositoryName, $packageIdOrName, $url, $credentialId = null, $type = 'vcs', $defaultSubrepositoryAccess = null)
     {
         $data = new VcsPackageConfig($url, $credentialId, $type, $defaultSubrepositoryAccess);
 
-        return $this->put(sprintf('/subrepositories/%s/packages/%s/', $subrepositoryName, $packageName), $data->toParameters());
+        return $this->put(sprintf('/subrepositories/%s/packages/%s/', $subrepositoryName, $packageIdOrName), $data->toParameters());
     }
 
-    public function editCustomPackage($subrepositoryName, $packageName, $customJson, $credentialId = null, $defaultSubrepositoryAccess = null)
+    public function editCustomPackage($subrepositoryName, $packageIdOrName, $customJson, $credentialId = null, $defaultSubrepositoryAccess = null)
     {
         $data = new CustomPackageConfig($customJson, $credentialId, $defaultSubrepositoryAccess);
 
-        return $this->put(sprintf('/subrepositories/%s/packages/%s/', $subrepositoryName, $packageName), $data->toParameters());
+        return $this->put(sprintf('/subrepositories/%s/packages/%s/', $subrepositoryName, $packageIdOrName), $data->toParameters());
     }
 
-    public function remove($subrepositoryName, $packageName)
+    public function remove($subrepositoryName, $packageIdOrName)
     {
-        return $this->delete(sprintf('/subrepositories/%s/packages/%s/', $subrepositoryName, $packageName));
+        return $this->delete(sprintf('/subrepositories/%s/packages/%s/', $subrepositoryName, $packageIdOrName));
     }
 
-    public function listDependents($subrepositoryName, $packageName)
+    public function listDependents($subrepositoryName, $packageIdOrName)
     {
-        return $this->get(sprintf('/subrepositories/%s/packages/%s/dependents/', $subrepositoryName, $packageName));
+        return $this->get(sprintf('/subrepositories/%s/packages/%s/dependents/', $subrepositoryName, $packageIdOrName));
     }
 }


### PR DESCRIPTION
Changes the `$packageName` function argument to `$packageIdOrName` where applicable, and explains the use of package IDs in the README for subrepositories.