### PR TITLE
Use getCollection() for all list endpoints

### DIFF
--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -58,9 +58,8 @@ abstract class AbstractApi
      */
     protected function getCollection($path, array $parameters = [], array $headers = [])
     {
-        if (count($parameters) > 0) {
-            $path .= '?'.http_build_query($parameters);
-        }
+        $parameters = array_merge(['limit' => self::DEFAULT_LIMIT], $parameters);
+        $path .= '?'.http_build_query($parameters);
 
         $content = [];
         $nextUrl = $path;

--- a/src/Api/Credentials.php
+++ b/src/Api/Credentials.php
@@ -21,7 +21,7 @@ class Credentials extends AbstractApi
 
     public function all()
     {
-        return $this->get('/credentials/', ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection('/credentials/');
     }
 
     public function show($credentialId)

--- a/src/Api/Customers.php
+++ b/src/Api/Customers.php
@@ -16,7 +16,7 @@ class Customers extends AbstractApi
 {
     public function all()
     {
-        return $this->get('/customers/', ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection('/customers/');
     }
 
     public function show($customerIdOrUrlName)
@@ -70,7 +70,7 @@ class Customers extends AbstractApi
 
     public function listPackages($customerIdOrUrlName)
     {
-        return $this->get(sprintf('/customers/%s/packages/', $customerIdOrUrlName), ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection(sprintf('/customers/%s/packages/', $customerIdOrUrlName));
     }
 
     public function showPackage($customerIdOrUrlName, $packageIdOrName)

--- a/src/Api/Customers/MagentoLegacyKeys.php
+++ b/src/Api/Customers/MagentoLegacyKeys.php
@@ -15,7 +15,7 @@ class MagentoLegacyKeys extends AbstractApi
 {
     public function all($customerIdOrUrlName)
     {
-        return $this->get(sprintf('/api/customers/%s/magento-legacy-keys/', $customerIdOrUrlName), ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection(sprintf('/api/customers/%s/magento-legacy-keys/', $customerIdOrUrlName));
     }
 
     public function create($customerIdOrUrlName, $publicKey, $privateKey)

--- a/src/Api/Customers/VendorBundles.php
+++ b/src/Api/Customers/VendorBundles.php
@@ -15,7 +15,7 @@ class VendorBundles extends AbstractApi
 {
     public function listVendorBundles($customerIdOrUrlName)
     {
-        return $this->get(sprintf('/customers/%s/vendor-bundles/', $customerIdOrUrlName), ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection(sprintf('/customers/%s/vendor-bundles/', $customerIdOrUrlName));
     }
 
     /**

--- a/src/Api/MirroredRepositories.php
+++ b/src/Api/MirroredRepositories.php
@@ -13,7 +13,7 @@ class MirroredRepositories extends AbstractApi
 {
     public function all()
     {
-        return $this->get('/mirrored-repositories/', ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection('/mirrored-repositories/');
     }
 
     public function create($name, $url, $mirroringBehavior, $credentials = null)
@@ -48,7 +48,7 @@ class MirroredRepositories extends AbstractApi
 
     public function listPackages($mirroredRepositoryId)
     {
-        return $this->get(sprintf('/mirrored-repositories/%s/packages/', $mirroredRepositoryId), ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection(sprintf('/mirrored-repositories/%s/packages/', $mirroredRepositoryId));
     }
 
     public function addPackages($mirroredRepositoryId, array $packages)

--- a/src/Api/Packages.php
+++ b/src/Api/Packages.php
@@ -52,8 +52,6 @@ class Packages extends AbstractApi
             throw new InvalidArgumentException('Filter "origin" has to be one of: "' . implode('", "', self::AVAILABLE_ORIGINS) . '".');
         }
 
-        $filters = array_merge(['limit' => self::DEFAULT_LIMIT], $filters);
-
         return $this->getCollection('/packages/', $filters);
     }
 
@@ -129,19 +127,17 @@ class Packages extends AbstractApi
 
     public function listCustomers($packageIdOrName)
     {
-        return $this->get(sprintf('/packages/%s/customers/', $packageIdOrName), ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection(sprintf('/packages/%s/customers/', $packageIdOrName));
     }
 
     public function listDependents($packageName)
     {
-        return $this->get(sprintf('/packages/%s/dependents/', $packageName), ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection(sprintf('/packages/%s/dependents/', $packageName));
     }
 
     public function listSecurityIssues($packageIdOrName, array $filters = [])
     {
-        $filters = array_merge(['limit' => self::DEFAULT_LIMIT], $filters);
-
-        return $this->get(sprintf('/packages/%s/security-issues/', $packageIdOrName), $filters);
+        return $this->getCollection(sprintf('/packages/%s/security-issues/', $packageIdOrName), $filters);
     }
 
     public function showSecurityMonitoringConfig($packageIdOrName)

--- a/src/Api/Packages/Artifacts.php
+++ b/src/Api/Packages/Artifacts.php
@@ -36,6 +36,6 @@ class Artifacts extends AbstractApi
 
     public function showPackageArtifacts($packageIdOrName)
     {
-        return $this->get(sprintf('/packages/%s/artifacts/', $packageIdOrName), ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection(sprintf('/packages/%s/artifacts/', $packageIdOrName));
     }
 }

--- a/src/Api/SecurityIssues.php
+++ b/src/Api/SecurityIssues.php
@@ -48,9 +48,7 @@ class SecurityIssues extends AbstractApi
 
     public function all(array $filters = [])
     {
-        $filters = array_merge(['limit' => self::DEFAULT_LIMIT], $filters);
-
-        return $this->get('/security-issues/', $filters);
+        return $this->getCollection('/security-issues/', $filters);
     }
 
     public function show(int $issueId): array

--- a/src/Api/Suborganizations.php
+++ b/src/Api/Suborganizations.php
@@ -15,7 +15,7 @@ class Suborganizations extends AbstractApi
 {
     public function all()
     {
-        return $this->get('/suborganizations/', ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection('/suborganizations/');
     }
 
     public function show($suborganizationName)
@@ -35,7 +35,7 @@ class Suborganizations extends AbstractApi
 
     public function listTeams($suborganizationName)
     {
-        return $this->get(sprintf('/suborganizations/%s/teams/', $suborganizationName), ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection(sprintf('/suborganizations/%s/teams/', $suborganizationName));
     }
 
     public function addOrEditTeams($suborganizationName, array $teams)
@@ -60,7 +60,7 @@ class Suborganizations extends AbstractApi
 
     public function listTokens($suborganizationName)
     {
-        return $this->get(sprintf('/suborganizations/%s/tokens/', $suborganizationName), ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection(sprintf('/suborganizations/%s/tokens/', $suborganizationName));
     }
 
     public function createToken($suborganizationName, array $tokenData)

--- a/src/Api/Suborganizations/MirroredRepositories.php
+++ b/src/Api/Suborganizations/MirroredRepositories.php
@@ -16,7 +16,7 @@ class MirroredRepositories extends AbstractApi
 {
     public function all($suborganizationName)
     {
-        return $this->get(sprintf('/suborganizations/%s/mirrored-repositories/', $suborganizationName), ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection(sprintf('/suborganizations/%s/mirrored-repositories/', $suborganizationName));
     }
 
     public function add($suborganizationName, array $mirroredRepositories)
@@ -49,7 +49,7 @@ class MirroredRepositories extends AbstractApi
 
     public function listPackages($suborganizationName, $mirroredRepositoryId)
     {
-        return $this->get(sprintf('/suborganizations/%s/mirrored-repositories/%s/packages/', $suborganizationName, $mirroredRepositoryId), ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection(sprintf('/suborganizations/%s/mirrored-repositories/%s/packages/', $suborganizationName, $mirroredRepositoryId));
     }
 
     public function addPackages($suborganizationName, $mirroredRepositoryId, array $packages)

--- a/src/Api/Suborganizations/Packages.php
+++ b/src/Api/Suborganizations/Packages.php
@@ -22,9 +22,7 @@ class Packages extends AbstractApi
             throw new InvalidArgumentException('Filter "origin" has to be one of: "' . implode('", "', \PrivatePackagist\ApiClient\Api\Packages::AVAILABLE_ORIGINS) . '".');
         }
 
-        $filters = array_merge(['limit' => self::DEFAULT_LIMIT], $filters);
-
-        return $this->get(sprintf('/suborganizations/%s/packages/', $suborganizationName), $filters);
+        return $this->getCollection(sprintf('/suborganizations/%s/packages/', $suborganizationName), $filters);
     }
 
     public function show($suborganizationName, $packageIdOrName)
@@ -67,6 +65,6 @@ class Packages extends AbstractApi
 
     public function listDependents($suborganizationName, $packageIdOrName)
     {
-        return $this->get(sprintf('/suborganizations/%s/packages/%s/dependents/', $suborganizationName, $packageIdOrName), ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection(sprintf('/suborganizations/%s/packages/%s/dependents/', $suborganizationName, $packageIdOrName));
     }
 }

--- a/src/Api/Subrepositories.php
+++ b/src/Api/Subrepositories.php
@@ -18,7 +18,7 @@ class Subrepositories extends AbstractApi
 {
     public function all()
     {
-        return $this->get('/subrepositories/', ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection('/subrepositories/');
     }
 
     public function show($subrepositoryName)
@@ -38,7 +38,7 @@ class Subrepositories extends AbstractApi
 
     public function listTeams($subrepositoryName)
     {
-        return $this->get(sprintf('/subrepositories/%s/teams/', $subrepositoryName), ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection(sprintf('/subrepositories/%s/teams/', $subrepositoryName));
     }
 
     /**
@@ -76,12 +76,12 @@ class Subrepositories extends AbstractApi
     #[\Deprecated('Use Subrepositories::packages()->all() instead', '1.16.1')]
     public function listPackages($subrepositoryName)
     {
-        return $this->packages()->all($subrepositoryName, ['limit' => self::DEFAULT_LIMIT]);
+        return $this->packages()->all($subrepositoryName);
     }
 
     public function listTokens($subrepositoryName)
     {
-        return $this->get(sprintf('/subrepositories/%s/tokens/', $subrepositoryName), ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection(sprintf('/subrepositories/%s/tokens/', $subrepositoryName));
     }
 
     public function createToken($subrepositoryName, array $tokenData)

--- a/src/Api/Subrepositories/MirroredRepositories.php
+++ b/src/Api/Subrepositories/MirroredRepositories.php
@@ -19,7 +19,7 @@ class MirroredRepositories extends AbstractApi
 {
     public function all($subrepositoryName)
     {
-        return $this->get(sprintf('/subrepositories/%s/mirrored-repositories/', $subrepositoryName), ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection(sprintf('/subrepositories/%s/mirrored-repositories/', $subrepositoryName));
     }
 
     public function add($subrepositoryName, array $mirroredRepositories)
@@ -52,7 +52,7 @@ class MirroredRepositories extends AbstractApi
 
     public function listPackages($subrepositoryName, $mirroredRepositoryId)
     {
-        return $this->get(sprintf('/subrepositories/%s/mirrored-repositories/%s/packages/', $subrepositoryName, $mirroredRepositoryId), ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection(sprintf('/subrepositories/%s/mirrored-repositories/%s/packages/', $subrepositoryName, $mirroredRepositoryId));
     }
 
     public function addPackages($subrepositoryName, $mirroredRepositoryId, array $packages)

--- a/src/Api/Subrepositories/Packages.php
+++ b/src/Api/Subrepositories/Packages.php
@@ -25,9 +25,7 @@ class Packages extends AbstractApi
             throw new InvalidArgumentException('Filter "origin" has to be one of: "' . implode('", "', \PrivatePackagist\ApiClient\Api\Packages::AVAILABLE_ORIGINS) . '".');
         }
 
-        $filters = array_merge(['limit' => self::DEFAULT_LIMIT], $filters);
-
-        return $this->get(sprintf('/subrepositories/%s/packages/', $subrepositoryName), $filters);
+        return $this->getCollection(sprintf('/subrepositories/%s/packages/', $subrepositoryName), $filters);
     }
 
     public function show($subrepositoryName, $packageIdOrName)
@@ -70,6 +68,6 @@ class Packages extends AbstractApi
 
     public function listDependents($subrepositoryName, $packageIdOrName)
     {
-        return $this->get(sprintf('/subrepositories/%s/packages/%s/dependents/', $subrepositoryName, $packageIdOrName), ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection(sprintf('/subrepositories/%s/packages/%s/dependents/', $subrepositoryName, $packageIdOrName));
     }
 }

--- a/src/Api/Synchronizations.php
+++ b/src/Api/Synchronizations.php
@@ -13,6 +13,6 @@ class Synchronizations extends AbstractApi
 {
     public function all()
     {
-        return $this->get('/synchronizations/', ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection('/synchronizations/');
     }
 }

--- a/src/Api/Teams.php
+++ b/src/Api/Teams.php
@@ -15,7 +15,7 @@ class Teams extends AbstractApi
 {
     public function all()
     {
-        return $this->get('/teams/', ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection('/teams/');
     }
 
     public function create(string $name, TeamPermissions $permissions): array
@@ -82,7 +82,7 @@ class Teams extends AbstractApi
 
     public function packages($teamId)
     {
-        return $this->get(sprintf('/teams/%s/packages/', $teamId), ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection(sprintf('/teams/%s/packages/', $teamId));
     }
 
     public function addPackages($teamId, array $packages)

--- a/src/Api/Tokens.php
+++ b/src/Api/Tokens.php
@@ -15,7 +15,7 @@ class Tokens extends AbstractApi
 {
     public function all()
     {
-        return $this->get('/tokens/', ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection('/tokens/');
     }
 
     public function create(array $tokenData)

--- a/src/Api/VendorBundles.php
+++ b/src/Api/VendorBundles.php
@@ -16,7 +16,7 @@ class VendorBundles extends AbstractApi
      */
     public function all()
     {
-        return $this->get('/vendor-bundles/', ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection('/vendor-bundles/');
     }
 
     /**

--- a/src/Api/VendorBundles/Packages.php
+++ b/src/Api/VendorBundles/Packages.php
@@ -20,7 +20,7 @@ class Packages extends AbstractApi
      */
     public function listPackages($vendorBundleIds)
     {
-        return $this->get(sprintf('/vendor-bundles/%s/packages/', $vendorBundleIds), ['limit' => self::DEFAULT_LIMIT]);
+        return $this->getCollection(sprintf('/vendor-bundles/%s/packages/', $vendorBundleIds));
     }
 
     /**

--- a/tests/Api/CredentialsTest.php
+++ b/tests/Api/CredentialsTest.php
@@ -29,8 +29,8 @@ class CredentialsTest extends ApiTestCase
         /** @var Credentials&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/credentials/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/credentials/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->all());

--- a/tests/Api/Customers/MagentoLegacyKeysTest.php
+++ b/tests/Api/Customers/MagentoLegacyKeysTest.php
@@ -10,7 +10,6 @@
 namespace PrivatePackagist\ApiClient\Api\Customers;
 
 use PHPUnit\Framework\MockObject\MockObject;
-use PrivatePackagist\ApiClient\Api\AbstractApi;
 use PrivatePackagist\ApiClient\Api\ApiTestCase;
 
 class MagentoLegacyKeysTest extends ApiTestCase
@@ -27,8 +26,8 @@ class MagentoLegacyKeysTest extends ApiTestCase
         /** @var MagentoLegacyKeys&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/api/customers/13/magento-legacy-keys/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/api/customers/13/magento-legacy-keys/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->all(13));

--- a/tests/Api/Customers/VendorBundlesTest.php
+++ b/tests/Api/Customers/VendorBundlesTest.php
@@ -10,7 +10,6 @@
 namespace PrivatePackagist\ApiClient\Api\Customers;
 
 use PHPUnit\Framework\MockObject\MockObject;
-use PrivatePackagist\ApiClient\Api\AbstractApi;
 use PrivatePackagist\ApiClient\Api\ApiTestCase;
 
 class VendorBundlesTest extends ApiTestCase
@@ -27,8 +26,8 @@ class VendorBundlesTest extends ApiTestCase
         /** @var VendorBundles&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/customers/1/vendor-bundles/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/customers/1/vendor-bundles/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->listVendorBundles(1));

--- a/tests/Api/CustomersTest.php
+++ b/tests/Api/CustomersTest.php
@@ -28,8 +28,8 @@ class CustomersTest extends ApiTestCase
         /** @var Customers&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/customers/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/customers/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->all());
@@ -204,8 +204,8 @@ class CustomersTest extends ApiTestCase
         /** @var Customers&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/customers/1/packages/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/customers/1/packages/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->listPackages(1));

--- a/tests/Api/MirroredRepositoriesTest.php
+++ b/tests/Api/MirroredRepositoriesTest.php
@@ -22,8 +22,8 @@ class MirroredRepositoriesTest extends ApiTestCase
         /** @var MirroredRepositories&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/mirrored-repositories/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/mirrored-repositories/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->all());
@@ -96,8 +96,8 @@ class MirroredRepositoriesTest extends ApiTestCase
         /** @var MirroredRepositories&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/mirrored-repositories/1/packages/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/mirrored-repositories/1/packages/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->listPackages(1));

--- a/tests/Api/Packages/ArtifactsTest.php
+++ b/tests/Api/Packages/ArtifactsTest.php
@@ -10,7 +10,6 @@
 namespace PrivatePackagist\ApiClient\Api\Packages;
 
 use PHPUnit\Framework\MockObject\MockObject;
-use PrivatePackagist\ApiClient\Api\AbstractApi;
 use PrivatePackagist\ApiClient\Api\ApiTestCase;
 
 class ArtifactsTest extends ApiTestCase
@@ -88,8 +87,8 @@ class ArtifactsTest extends ApiTestCase
         /** @var Artifacts&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/packages/acme-website/package/artifacts/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/packages/acme-website/package/artifacts/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->showPackageArtifacts('acme-website/package'));

--- a/tests/Api/PackagesTest.php
+++ b/tests/Api/PackagesTest.php
@@ -46,16 +46,11 @@ class PackagesTest extends ApiTestCase
             'origin' => Packages::ORIGIN_PRIVATE,
         ];
 
-        $expectedQueryParams = [
-            'origin' => Packages::ORIGIN_PRIVATE,
-            'limit' => AbstractApi::DEFAULT_LIMIT,
-        ];
-
         /** @var Packages&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('getCollection')
-            ->with($this->equalTo('/packages/'), $this->equalTo($expectedQueryParams))
+            ->with($this->equalTo('/packages/'), $this->equalTo($filters))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->all($filters));
@@ -277,8 +272,8 @@ class PackagesTest extends ApiTestCase
         /** @var Packages&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/packages/composer/composer/customers/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/packages/composer/composer/customers/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->listCustomers('composer/composer'));
@@ -297,8 +292,8 @@ class PackagesTest extends ApiTestCase
         /** @var Packages&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/packages/acme-website/core-package/dependents/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/packages/acme-website/core-package/dependents/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->listDependents($packageName));
@@ -326,8 +321,8 @@ class PackagesTest extends ApiTestCase
         /** @var Packages&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/packages/acme-website/core-package/security-issues/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/packages/acme-website/core-package/security-issues/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->listSecurityIssues($packageName));

--- a/tests/Api/Projects/MirroredRepositoriesTest.php
+++ b/tests/Api/Projects/MirroredRepositoriesTest.php
@@ -10,7 +10,6 @@
 namespace PrivatePackagist\ApiClient\Api\Projects;
 
 use PHPUnit\Framework\MockObject\MockObject;
-use PrivatePackagist\ApiClient\Api\AbstractApi;
 use PrivatePackagist\ApiClient\Api\ApiTestCase;
 
 class MirroredRepositoriesTest extends ApiTestCase
@@ -25,8 +24,8 @@ class MirroredRepositoriesTest extends ApiTestCase
         /** @var MirroredRepositories&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/subrepositories/project/mirrored-repositories/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/subrepositories/project/mirrored-repositories/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->all($projectName));
@@ -108,8 +107,8 @@ class MirroredRepositoriesTest extends ApiTestCase
         /** @var MirroredRepositories&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/subrepositories/project/mirrored-repositories/1/packages/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/subrepositories/project/mirrored-repositories/1/packages/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->listPackages($projectName, 1));

--- a/tests/Api/Projects/PackagesTest.php
+++ b/tests/Api/Projects/PackagesTest.php
@@ -10,7 +10,6 @@
 namespace PrivatePackagist\ApiClient\Api\Projects;
 
 use PHPUnit\Framework\MockObject\MockObject;
-use PrivatePackagist\ApiClient\Api\AbstractApi;
 use PrivatePackagist\ApiClient\Api\ApiTestCase;
 use PrivatePackagist\ApiClient\Exception\InvalidArgumentException;
 
@@ -29,8 +28,8 @@ class PackagesTest extends ApiTestCase
         /** @var Packages&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/subrepositories/project/packages/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/subrepositories/project/packages/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->all($projectName));
@@ -50,16 +49,11 @@ class PackagesTest extends ApiTestCase
             'origin' => \PrivatePackagist\ApiClient\Api\Packages::ORIGIN_PRIVATE,
         ];
 
-        $expectedQueryParams = [
-            'origin' => \PrivatePackagist\ApiClient\Api\Packages::ORIGIN_PRIVATE,
-            'limit' => AbstractApi::DEFAULT_LIMIT,
-        ];
-
         /** @var Packages&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/subrepositories/project/packages/'), $this->equalTo($expectedQueryParams))
+            ->method('getCollection')
+            ->with($this->equalTo('/subrepositories/project/packages/'), $this->equalTo($filters))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->all($projectName, $filters));

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -22,8 +22,8 @@ class ProjectsTest extends ApiTestCase
         /** @var Projects&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/subrepositories/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/subrepositories/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->all());
@@ -88,8 +88,8 @@ class ProjectsTest extends ApiTestCase
         /** @var Projects&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/subrepositories/project/teams/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/subrepositories/project/teams/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->listTeams('project'));
@@ -149,8 +149,8 @@ class ProjectsTest extends ApiTestCase
         /** @var Projects&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/subrepositories/project/tokens/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/subrepositories/project/tokens/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->listTokens('project'));

--- a/tests/Api/SecurityIssuesTest.php
+++ b/tests/Api/SecurityIssuesTest.php
@@ -34,7 +34,7 @@ class SecurityIssuesTest extends ApiTestCase
         /** @var SecurityIssues&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
+            ->method('getCollection')
             ->with($this->equalTo('/security-issues/'))
             ->willReturn($expected);
 
@@ -63,16 +63,11 @@ class SecurityIssuesTest extends ApiTestCase
             'security-issue-state' => SecurityIssues::STATE_OPEN,
         ];
 
-        $expectedQueryParams = [
-            'security-issue-state' => SecurityIssues::STATE_OPEN,
-            'limit' => AbstractApi::DEFAULT_LIMIT,
-        ];
-
         /** @var SecurityIssues&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/security-issues/'), $this->equalTo($expectedQueryParams))
+            ->method('getCollection')
+            ->with($this->equalTo('/security-issues/'), $this->equalTo($filters))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->all($filters));

--- a/tests/Api/Suborganizations/MirroredRepositoriesTest.php
+++ b/tests/Api/Suborganizations/MirroredRepositoriesTest.php
@@ -10,7 +10,6 @@
 namespace PrivatePackagist\ApiClient\Api\Suborganizations;
 
 use PHPUnit\Framework\MockObject\MockObject;
-use PrivatePackagist\ApiClient\Api\AbstractApi;
 use PrivatePackagist\ApiClient\Api\ApiTestCase;
 
 class MirroredRepositoriesTest extends ApiTestCase
@@ -25,8 +24,8 @@ class MirroredRepositoriesTest extends ApiTestCase
         /** @var MirroredRepositories&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/suborganizations/suborganization/mirrored-repositories/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/suborganizations/suborganization/mirrored-repositories/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->all($suborganizationName));
@@ -108,8 +107,8 @@ class MirroredRepositoriesTest extends ApiTestCase
         /** @var MirroredRepositories&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/suborganizations/suborganization/mirrored-repositories/1/packages/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/suborganizations/suborganization/mirrored-repositories/1/packages/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->listPackages($suborganizationName, 1));

--- a/tests/Api/Suborganizations/PackagesTest.php
+++ b/tests/Api/Suborganizations/PackagesTest.php
@@ -10,7 +10,6 @@
 namespace PrivatePackagist\ApiClient\Api\Suborganizations;
 
 use PHPUnit\Framework\MockObject\MockObject;
-use PrivatePackagist\ApiClient\Api\AbstractApi;
 use PrivatePackagist\ApiClient\Api\ApiTestCase;
 use PrivatePackagist\ApiClient\Exception\InvalidArgumentException;
 
@@ -29,8 +28,8 @@ class PackagesTest extends ApiTestCase
         /** @var Packages&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/suborganizations/suborganization/packages/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/suborganizations/suborganization/packages/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->all($suborganizationName));
@@ -50,16 +49,11 @@ class PackagesTest extends ApiTestCase
             'origin' => \PrivatePackagist\ApiClient\Api\Packages::ORIGIN_PRIVATE,
         ];
 
-        $expectedQueryParams = [
-            'origin' => \PrivatePackagist\ApiClient\Api\Packages::ORIGIN_PRIVATE,
-            'limit' => AbstractApi::DEFAULT_LIMIT,
-        ];
-
         /** @var Packages&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/suborganizations/suborganization/packages/'), $this->equalTo($expectedQueryParams))
+            ->method('getCollection')
+            ->with($this->equalTo('/suborganizations/suborganization/packages/'), $this->equalTo($filters))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->all($suborganizationName, $filters));
@@ -212,8 +206,8 @@ class PackagesTest extends ApiTestCase
         /** @var Packages&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/suborganizations/suborganization/packages/acme-website/core-package/dependents/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/suborganizations/suborganization/packages/acme-website/core-package/dependents/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->listDependents($suborganizationName, $packageName));

--- a/tests/Api/SuborganizationsTest.php
+++ b/tests/Api/SuborganizationsTest.php
@@ -22,8 +22,8 @@ class SuborganizationsTest extends ApiTestCase
         /** @var Suborganizations&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/suborganizations/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/suborganizations/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->all());
@@ -88,8 +88,8 @@ class SuborganizationsTest extends ApiTestCase
         /** @var Suborganizations&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/suborganizations/suborganization/teams/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/suborganizations/suborganization/teams/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->listTeams('suborganization'));
@@ -149,8 +149,8 @@ class SuborganizationsTest extends ApiTestCase
         /** @var Suborganizations&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/suborganizations/suborganization/tokens/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/suborganizations/suborganization/tokens/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->listTokens('suborganization'));

--- a/tests/Api/Subrepositories/MirroredRepositoriesTest.php
+++ b/tests/Api/Subrepositories/MirroredRepositoriesTest.php
@@ -10,7 +10,6 @@
 namespace PrivatePackagist\ApiClient\Api\Subrepositories;
 
 use PHPUnit\Framework\MockObject\MockObject;
-use PrivatePackagist\ApiClient\Api\AbstractApi;
 use PrivatePackagist\ApiClient\Api\ApiTestCase;
 
 class MirroredRepositoriesTest extends ApiTestCase
@@ -25,8 +24,8 @@ class MirroredRepositoriesTest extends ApiTestCase
         /** @var MirroredRepositories&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/subrepositories/subrepository/mirrored-repositories/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/subrepositories/subrepository/mirrored-repositories/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->all($subrepositoryName));
@@ -108,8 +107,8 @@ class MirroredRepositoriesTest extends ApiTestCase
         /** @var MirroredRepositories&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/subrepositories/subrepository/mirrored-repositories/1/packages/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/subrepositories/subrepository/mirrored-repositories/1/packages/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->listPackages($subrepositoryName, 1));

--- a/tests/Api/Subrepositories/PackagesTest.php
+++ b/tests/Api/Subrepositories/PackagesTest.php
@@ -10,7 +10,6 @@
 namespace PrivatePackagist\ApiClient\Api\Subrepositories;
 
 use PHPUnit\Framework\MockObject\MockObject;
-use PrivatePackagist\ApiClient\Api\AbstractApi;
 use PrivatePackagist\ApiClient\Api\ApiTestCase;
 use PrivatePackagist\ApiClient\Exception\InvalidArgumentException;
 
@@ -29,8 +28,8 @@ class PackagesTest extends ApiTestCase
         /** @var Packages&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/subrepositories/subrepository/packages/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/subrepositories/subrepository/packages/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->all($subrepositoryName));
@@ -50,16 +49,11 @@ class PackagesTest extends ApiTestCase
             'origin' => \PrivatePackagist\ApiClient\Api\Packages::ORIGIN_PRIVATE,
         ];
 
-        $expectedQueryParams = [
-            'origin' => \PrivatePackagist\ApiClient\Api\Packages::ORIGIN_PRIVATE,
-            'limit' => AbstractApi::DEFAULT_LIMIT,
-        ];
-
         /** @var Packages&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/subrepositories/subrepository/packages/'), $this->equalTo($expectedQueryParams))
+            ->method('getCollection')
+            ->with($this->equalTo('/subrepositories/subrepository/packages/'), $this->equalTo($filters))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->all($subrepositoryName, $filters));
@@ -212,8 +206,8 @@ class PackagesTest extends ApiTestCase
         /** @var Packages&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/subrepositories/subrepository/packages/acme-website/core-package/dependents/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/subrepositories/subrepository/packages/acme-website/core-package/dependents/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->listDependents($subrepositoryName, $packageName));

--- a/tests/Api/SubrepositoriesTest.php
+++ b/tests/Api/SubrepositoriesTest.php
@@ -22,8 +22,8 @@ class SubrepositoriesTest extends ApiTestCase
         /** @var Subrepositories&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/subrepositories/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/subrepositories/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->all());
@@ -88,8 +88,8 @@ class SubrepositoriesTest extends ApiTestCase
         /** @var Subrepositories&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/subrepositories/subrepository/teams/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/subrepositories/subrepository/teams/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->listTeams('subrepository'));
@@ -149,8 +149,8 @@ class SubrepositoriesTest extends ApiTestCase
         /** @var Subrepositories&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/subrepositories/subrepository/tokens/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/subrepositories/subrepository/tokens/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->listTokens('subrepository'));

--- a/tests/Api/SynchronizationsTest.php
+++ b/tests/Api/SynchronizationsTest.php
@@ -32,8 +32,8 @@ class SynchronizationsTest extends ApiTestCase
         /** @var Synchronizations&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/synchronizations/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/synchronizations/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->all());

--- a/tests/Api/TeamsTest.php
+++ b/tests/Api/TeamsTest.php
@@ -35,8 +35,8 @@ class TeamsTest extends ApiTestCase
         /** @var Teams&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/teams/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/teams/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->all());
@@ -54,8 +54,8 @@ class TeamsTest extends ApiTestCase
         /** @var Teams&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/teams/1/packages/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/teams/1/packages/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->packages(1));

--- a/tests/Api/TokensTest.php
+++ b/tests/Api/TokensTest.php
@@ -30,8 +30,8 @@ class TokensTest extends ApiTestCase
         /** @var Tokens&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/tokens/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->equalTo('/tokens/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->all());

--- a/tests/Api/VendorBundles/PackagesTest.php
+++ b/tests/Api/VendorBundles/PackagesTest.php
@@ -10,7 +10,6 @@
 namespace PrivatePackagist\ApiClient\Api\VendorBundles;
 
 use PHPUnit\Framework\MockObject\MockObject;
-use PrivatePackagist\ApiClient\Api\AbstractApi;
 use PrivatePackagist\ApiClient\Api\ApiTestCase;
 use PrivatePackagist\ApiClient\Exception\InvalidArgumentException;
 
@@ -29,8 +28,8 @@ class PackagesTest extends ApiTestCase
         /** @var Packages&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->identicalTo('/vendor-bundles/1/packages/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->identicalTo('/vendor-bundles/1/packages/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->listPackages(1));

--- a/tests/Api/VendorBundlesTest.php
+++ b/tests/Api/VendorBundlesTest.php
@@ -29,8 +29,8 @@ class VendorBundlesTest extends ApiTestCase
         /** @var VendorBundles&MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
-            ->with($this->identicalTo('/vendor-bundles/'), $this->identicalTo(['limit' => AbstractApi::DEFAULT_LIMIT]))
+            ->method('getCollection')
+            ->with($this->identicalTo('/vendor-bundles/'))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->all());


### PR DESCRIPTION
## Summary
- Moved the default limit (`DEFAULT_LIMIT`) into `getCollection()` so callers no longer need to set it explicitly
- Switched all list/collection endpoints from `get()` to `getCollection()` to enable automatic pagination across all API resources (teams, customers, credentials, tokens, mirrored repositories, vendor bundles, etc.)
- Previously only `Packages::all()` used `getCollection()`, now all list endpoints benefit from auto-pagination