### PR TITLE
Better dev tooling, CLAUDE.md, improve CI, update actions

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -40,7 +40,7 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: PHPUnit
-        run: ./vendor/bin/phpunit tests
+        run: ./vendor/bin/phpunit
 
       - name: PHP-CS-Fixer
         run: ./vendor/bin/php-cs-fixer fix --dry-run --diff
@@ -48,4 +48,4 @@ jobs:
           PHP_CS_FIXER_IGNORE_ENV: 1
 
       - name: PHPStan
-        run: ./vendor/bin/phpstan analyze src --no-progress
+        run: ./vendor/bin/phpstan analyze --no-progress

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -24,7 +24,7 @@ jobs:
           - "8.4"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ vendor
 composer.lock
 
 README.md.*
+/.idea/
+/.serena/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+# Private Packagist API Client
+
+PHP API client for Private Packagist.
+
+## Commands
+
+- `composer test` — Run tests
+- `composer cs-fix` — Fix code style (src + tests)
+- `composer analyze` — Run PHPStan static analysis
+
+## Architecture
+
+- `src/Api/AbstractApi.php` — Base class for all API endpoints. Provides `get()` for single resources and `getCollection()` for list endpoints with auto-pagination.
+- `src/Api/*.php` — API endpoint classes (Packages, Teams, Customers, etc.)
+- `src/Api/*/` — Nested API endpoints (e.g. `Customers/VendorBundles`, `Packages/Artifacts`)
+- `src/Client.php` — Entry point, provides access to all API classes
+
+## Notes
+
+- Supports PHP 7.2+ — avoid modern syntax not available in 7.2
+
+## Conventions
+
+- List endpoints use `getCollection()` (handles pagination and default limit)
+- Single-resource endpoints use `get()`

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,9 @@
         "psr-4": { "PrivatePackagist\\ApiClient\\": "tests/"}
     },
     "scripts": {
+        "analyze": "phpstan analyze --no-progress",
+        "cs-fix": "php-cs-fixer fix",
+        "test": "phpunit",
         "toc": "./gh-md-toc --insert README.md"
     },
     "config": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
+</phpunit>


### PR DESCRIPTION
I noticed that Claude struggled to run the tests in this repo, forgot to fix directories and didnt know that we run phpstan here.

Hence added better tooling for all of this and created the CLAUDE.md to support that.

## Summary
- Add `composer test` to run phpunit
- Add `composer cs-fix` to run php-cs-fixer (covers both src/ and tests/)
- Add `phpunit.xml.dist` so phpunit can run without specifying the tests directory
- Add `CLAUDE.md` with project conventions