### PR TITLE
Sign URL query parameters in API request signatures (v2)

### DIFF
--- a/src/HttpClient/Plugin/RequestSignature.php
+++ b/src/HttpClient/Plugin/RequestSignature.php
@@ -16,6 +16,11 @@ class RequestSignature implements Plugin
 {
     use Plugin\VersionBridgePlugin;
 
+    const SIGNATURE_VERSION = '2';
+
+    /** @var array<string> */
+    private static $reservedParams = ['key', 'timestamp', 'cnonce', 'signature', 'version', 'body'];
+
     /** @var string */
     private $key;
     /** @var string */
@@ -48,7 +53,23 @@ class RequestSignature implements Plugin
             'key' => $this->key,
             'timestamp' => $this->getTimestamp(),
             'cnonce' => $this->getNonce(),
+            'version' => self::SIGNATURE_VERSION,
         ];
+
+        // Query-string parameters are part of the signed payload in v2. Reserved auth fields
+        // cannot be set from the query string — this keeps signing symmetric with the server
+        // and prevents a caller from shadowing an auth field with a query param.
+        $queryString = $request->getUri()->getQuery();
+        if ($queryString !== '') {
+            $queryParams = [];
+            parse_str($queryString, $queryParams);
+            foreach ($queryParams as $key => $value) {
+                if (in_array($key, self::$reservedParams, true)) {
+                    continue;
+                }
+                $params[$key] = $value;
+            }
+        }
 
         $content = (string) $request->getBody();
         if ($content) {
@@ -56,10 +77,11 @@ class RequestSignature implements Plugin
         }
 
         $request = $request->withHeader('Authorization', sprintf(
-            'PACKAGIST-HMAC-SHA256 Key=%s, Timestamp=%s, Cnonce=%s, Signature=%s',
+            'PACKAGIST-HMAC-SHA256 Key=%s, Timestamp=%s, Cnonce=%s, Version=%s, Signature=%s',
             $params['key'],
             $params['timestamp'],
             $params['cnonce'],
+            $params['version'],
             $this->generateSignature($request, $params)
         ));
 

--- a/src/HttpClient/Plugin/RequestSignature.php
+++ b/src/HttpClient/Plugin/RequestSignature.php
@@ -18,9 +18,6 @@ class RequestSignature implements Plugin
 
     const SIGNATURE_VERSION = '2';
 
-    /** @var array<string> */
-    private static $reservedParams = ['key', 'timestamp', 'cnonce', 'signature', 'version', 'body'];
-
     /** @var string */
     private $key;
     /** @var string */
@@ -54,22 +51,8 @@ class RequestSignature implements Plugin
             'timestamp' => $this->getTimestamp(),
             'cnonce' => $this->getNonce(),
             'version' => self::SIGNATURE_VERSION,
+            'query' => $this->normalizeQueryString($request->getUri()->getQuery()),
         ];
-
-        // Query-string parameters are part of the signed payload in v2. Reserved auth fields
-        // cannot be set from the query string — this keeps signing symmetric with the server
-        // and prevents a caller from shadowing an auth field with a query param.
-        $queryString = $request->getUri()->getQuery();
-        if ($queryString !== '') {
-            $queryParams = [];
-            parse_str($queryString, $queryParams);
-            foreach ($queryParams as $key => $value) {
-                if (in_array($key, self::$reservedParams, true)) {
-                    continue;
-                }
-                $params[$key] = $value;
-            }
-        }
 
         $content = (string) $request->getBody();
         if ($content) {
@@ -115,5 +98,22 @@ class RequestSignature implements Plugin
         uksort($params, 'strcmp');
 
         return http_build_query($params, '', '&', PHP_QUERY_RFC3986);
+    }
+
+    /**
+     * @param string $queryString
+     * @return string
+     */
+    private function normalizeQueryString($queryString)
+    {
+        if ($queryString === '') {
+            return '';
+        }
+
+        $queryParams = [];
+        parse_str($queryString, $queryParams);
+        uksort($queryParams, 'strcmp');
+
+        return http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
     }
 }

--- a/tests/HttpClient/Plugin/RequestSignatureTest.php
+++ b/tests/HttpClient/Plugin/RequestSignatureTest.php
@@ -127,14 +127,14 @@ class RequestSignatureTest extends PluginTestCase
     {
         // Fixed reference vector: the server repo has a matching test asserting the same
         // signature for the same inputs. If either side's algorithm drifts, both tests break.
-        $request = new Request('GET', 'https://example.com/api/packages/?limit=1&page=2');
+        $request = new Request('GET', 'https://localhost/api/packages/?limit=1&page=2');
         $expected = "PACKAGIST-HMAC-SHA256 Key={$this->key}, Timestamp={$this->timestamp}, Cnonce={$this->nonce}, Version=2, Signature=";
 
         $actual = $this->plugin->handleRequest($request, $this->next, $this->first)->wait(true)->getHeader('Authorization')[0];
 
         $this->assertStringStartsWith($expected, $actual);
         // Exact signature bytes — must match server test in private-packagist repo
-        $this->assertStringEndsWith('Signature=K2K5pvOobioNvIvAyOvjowOpIiKucdo/oGWZXKYDiqM=', $actual);
+        $this->assertStringEndsWith('Signature=NUZO6kd85G+ujItfIKDHTnHLtn9Dk2St22+ioyRDC/E=', $actual);
     }
 
     private function extractSignature(RequestInterface $request)

--- a/tests/HttpClient/Plugin/RequestSignatureTest.php
+++ b/tests/HttpClient/Plugin/RequestSignatureTest.php
@@ -40,7 +40,7 @@ class RequestSignatureTest extends PluginTestCase
             'POST',
             '/packages/?foo=bar',
             [
-                'Authorization' => ["PACKAGIST-HMAC-SHA256 Key={$this->key}, Timestamp={$this->timestamp}, Cnonce={$this->nonce}, Version=2, Signature=ktD+pXXy+JCEAq9LJuq735Xe2tN3soymwdQlwHgsbmM="],
+                'Authorization' => ["PACKAGIST-HMAC-SHA256 Key={$this->key}, Timestamp={$this->timestamp}, Cnonce={$this->nonce}, Version=2, Signature=rzwvwGS17Qcmk8UqTefJCHCV188x1/e1iBWG2pB4z1M="],
             ],
             json_encode(['foo' => 'bar'])
         );
@@ -72,15 +72,14 @@ class RequestSignatureTest extends PluginTestCase
         $this->assertSame($signatureA, $signatureB);
     }
 
-    public function testQueryParamCannotOverrideAuthField()
+    public function testQueryParamWithAuthFieldNameDoesNotShadowAuthIdentity()
     {
-        $withoutTamper = new Request('GET', '/packages/');
-        $withTamper = new Request('GET', '/packages/?key=evil&version=1&signature=evil');
+        $request = new Request('GET', '/packages/?key=evil&version=1');
 
-        $signatureA = $this->extractSignature($this->plugin->handleRequest($withoutTamper, $this->next, $this->first)->wait(true));
-        $signatureB = $this->extractSignature($this->plugin->handleRequest($withTamper, $this->next, $this->first)->wait(true));
+        $header = $this->plugin->handleRequest($request, $this->next, $this->first)->wait(true)->getHeader('Authorization')[0];
 
-        $this->assertSame($signatureA, $signatureB);
+        $this->assertStringContainsString("Key={$this->key}", $header);
+        $this->assertStringContainsString('Version=2', $header);
     }
 
     public function testEmptyQueryStringMatchesNoQueryString()
@@ -104,16 +103,12 @@ class RequestSignatureTest extends PluginTestCase
         $emptyValue = $this->extractSignature($this->plugin->handleRequest($withEmptyValue, $this->next, $this->first)->wait(true));
         $valueless = $this->extractSignature($this->plugin->handleRequest($withValuelessParam, $this->next, $this->first)->wait(true));
 
-        // The param participates in the signature even with an empty value
         $this->assertNotSame($baseline, $emptyValue);
-        // ?foo and ?foo= parse identically in PHP — must sign identically
         $this->assertSame($emptyValue, $valueless);
     }
 
     public function testUrlEncodingIsCanonical()
     {
-        // %20 (percent-encoded space) and + (form-encoded space) must decode
-        // to the same value and therefore sign identically.
         $percent = new Request('GET', '/packages/?foo=hello%20world');
         $plus = new Request('GET', '/packages/?foo=hello+world');
 
@@ -125,16 +120,13 @@ class RequestSignatureTest extends PluginTestCase
 
     public function testV2GetDeterministicSignature()
     {
-        // Fixed reference vector: the server repo has a matching test asserting the same
-        // signature for the same inputs. If either side's algorithm drifts, both tests break.
         $request = new Request('GET', 'https://localhost/api/packages/?limit=1&page=2');
         $expected = "PACKAGIST-HMAC-SHA256 Key={$this->key}, Timestamp={$this->timestamp}, Cnonce={$this->nonce}, Version=2, Signature=";
 
         $actual = $this->plugin->handleRequest($request, $this->next, $this->first)->wait(true)->getHeader('Authorization')[0];
 
         $this->assertStringStartsWith($expected, $actual);
-        // Exact signature bytes — must match server test in private-packagist repo
-        $this->assertStringEndsWith('Signature=NUZO6kd85G+ujItfIKDHTnHLtn9Dk2St22+ioyRDC/E=', $actual);
+        $this->assertStringEndsWith('Signature=RLb/mPCONIcfPp3+Ink+jtxNU6VKyeasf7Zdd7kNO+A=', $actual);
     }
 
     private function extractSignature(RequestInterface $request)

--- a/tests/HttpClient/Plugin/RequestSignatureTest.php
+++ b/tests/HttpClient/Plugin/RequestSignatureTest.php
@@ -10,6 +10,7 @@
 namespace PrivatePackagist\ApiClient\HttpClient\Plugin;
 
 use GuzzleHttp\Psr7\Request;
+use Psr\Http\Message\RequestInterface;
 
 class RequestSignatureTest extends PluginTestCase
 {
@@ -39,7 +40,7 @@ class RequestSignatureTest extends PluginTestCase
             'POST',
             '/packages/?foo=bar',
             [
-                'Authorization' => ["PACKAGIST-HMAC-SHA256 Key={$this->key}, Timestamp={$this->timestamp}, Cnonce={$this->nonce}, Signature=a6wxBLYrmz4Mwmv/TKBZR5WHFcSCRbsny2frobJMt24="],
+                'Authorization' => ["PACKAGIST-HMAC-SHA256 Key={$this->key}, Timestamp={$this->timestamp}, Cnonce={$this->nonce}, Version=2, Signature=ktD+pXXy+JCEAq9LJuq735Xe2tN3soymwdQlwHgsbmM="],
             ],
             json_encode(['foo' => 'bar'])
         );
@@ -47,6 +48,101 @@ class RequestSignatureTest extends PluginTestCase
         $promise = $this->plugin->handleRequest($request, $this->next, $this->first);
 
         $this->assertEquals($expected->getHeaders(), $promise->wait(true)->getHeaders());
+    }
+
+    public function testSignatureCoversQueryString()
+    {
+        $requestA = new Request('GET', '/packages/?page=1&limit=10');
+        $requestB = new Request('GET', '/packages/?page=2&limit=10');
+
+        $signatureA = $this->extractSignature($this->plugin->handleRequest($requestA, $this->next, $this->first)->wait(true));
+        $signatureB = $this->extractSignature($this->plugin->handleRequest($requestB, $this->next, $this->first)->wait(true));
+
+        $this->assertNotSame($signatureA, $signatureB);
+    }
+
+    public function testSignatureIgnoresQueryParamOrder()
+    {
+        $requestA = new Request('GET', '/packages/?page=1&limit=10');
+        $requestB = new Request('GET', '/packages/?limit=10&page=1');
+
+        $signatureA = $this->extractSignature($this->plugin->handleRequest($requestA, $this->next, $this->first)->wait(true));
+        $signatureB = $this->extractSignature($this->plugin->handleRequest($requestB, $this->next, $this->first)->wait(true));
+
+        $this->assertSame($signatureA, $signatureB);
+    }
+
+    public function testQueryParamCannotOverrideAuthField()
+    {
+        $withoutTamper = new Request('GET', '/packages/');
+        $withTamper = new Request('GET', '/packages/?key=evil&version=1&signature=evil');
+
+        $signatureA = $this->extractSignature($this->plugin->handleRequest($withoutTamper, $this->next, $this->first)->wait(true));
+        $signatureB = $this->extractSignature($this->plugin->handleRequest($withTamper, $this->next, $this->first)->wait(true));
+
+        $this->assertSame($signatureA, $signatureB);
+    }
+
+    public function testEmptyQueryStringMatchesNoQueryString()
+    {
+        $withoutQuery = new Request('GET', '/packages/');
+        $withEmptyQuery = new Request('GET', '/packages/?');
+
+        $signatureA = $this->extractSignature($this->plugin->handleRequest($withoutQuery, $this->next, $this->first)->wait(true));
+        $signatureB = $this->extractSignature($this->plugin->handleRequest($withEmptyQuery, $this->next, $this->first)->wait(true));
+
+        $this->assertSame($signatureA, $signatureB);
+    }
+
+    public function testEmptyValueQueryParamIsSigned()
+    {
+        $withoutParam = new Request('GET', '/packages/');
+        $withEmptyValue = new Request('GET', '/packages/?foo=');
+        $withValuelessParam = new Request('GET', '/packages/?foo');
+
+        $baseline = $this->extractSignature($this->plugin->handleRequest($withoutParam, $this->next, $this->first)->wait(true));
+        $emptyValue = $this->extractSignature($this->plugin->handleRequest($withEmptyValue, $this->next, $this->first)->wait(true));
+        $valueless = $this->extractSignature($this->plugin->handleRequest($withValuelessParam, $this->next, $this->first)->wait(true));
+
+        // The param participates in the signature even with an empty value
+        $this->assertNotSame($baseline, $emptyValue);
+        // ?foo and ?foo= parse identically in PHP — must sign identically
+        $this->assertSame($emptyValue, $valueless);
+    }
+
+    public function testUrlEncodingIsCanonical()
+    {
+        // %20 (percent-encoded space) and + (form-encoded space) must decode
+        // to the same value and therefore sign identically.
+        $percent = new Request('GET', '/packages/?foo=hello%20world');
+        $plus = new Request('GET', '/packages/?foo=hello+world');
+
+        $signaturePercent = $this->extractSignature($this->plugin->handleRequest($percent, $this->next, $this->first)->wait(true));
+        $signaturePlus = $this->extractSignature($this->plugin->handleRequest($plus, $this->next, $this->first)->wait(true));
+
+        $this->assertSame($signaturePercent, $signaturePlus);
+    }
+
+    public function testV2GetDeterministicSignature()
+    {
+        // Fixed reference vector: the server repo has a matching test asserting the same
+        // signature for the same inputs. If either side's algorithm drifts, both tests break.
+        $request = new Request('GET', 'https://example.com/api/packages/?limit=1&page=2');
+        $expected = "PACKAGIST-HMAC-SHA256 Key={$this->key}, Timestamp={$this->timestamp}, Cnonce={$this->nonce}, Version=2, Signature=";
+
+        $actual = $this->plugin->handleRequest($request, $this->next, $this->first)->wait(true)->getHeader('Authorization')[0];
+
+        $this->assertStringStartsWith($expected, $actual);
+        // Exact signature bytes — must match server test in private-packagist repo
+        $this->assertStringEndsWith('Signature=K2K5pvOobioNvIvAyOvjowOpIiKucdo/oGWZXKYDiqM=', $actual);
+    }
+
+    private function extractSignature(RequestInterface $request)
+    {
+        $header = $request->getHeader('Authorization')[0];
+        preg_match('/Signature=([^,]+)/', $header, $matches);
+
+        return $matches[1];
     }
 
     public function testPrefixRequestPathSmoke()


### PR DESCRIPTION
The HMAC signature plugin used to sign only the request method, host, path, and body. Query-string parameters appended to GET URLs (e.g. pagination) were not covered. An MITM could tamper with them without invalidating the signature.

Updates the plugin to emit `Version=2` in the Authorization header and include URL query parameters in the signed payload.