### PR TITLE
Remove single-use undeclared composer/pcre dependency with native preg_match

### DIFF
--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -9,7 +9,6 @@
 
 namespace PrivatePackagist\ApiClient\Api;
 
-use Composer\Pcre\Preg;
 use PrivatePackagist\ApiClient\Client;
 use PrivatePackagist\ApiClient\HttpClient\Message\ResponseMediator;
 
@@ -179,7 +178,7 @@ abstract class AbstractApi
     private function parseLinkHeader(string $header, string $type): ?string
     {
         foreach (explode(',', $header) as $relation) {
-            if (Preg::isMatch('/<(.*)>; rel="(.*)"/i', \trim($relation, ','), $match)) {
+            if (preg_match('/<(.*)>; rel="(.*)"/i', \trim($relation, ','), $match) === 1) {
                 /** @var string[] $match */
                 if (3 === count($match) && $match[2] === $type) {
                     return $match[1];


### PR DESCRIPTION
The single use of `Composer\Pcre\Preg::isMatch` in `AbstractApi::parseLinkHeader` relied on `composer/pcre` being available transitively via `composer/xdebug-handler` (a dev dependency of `friendsofphp/php-cs-fixer`). Downstream projects that install `private-packagist/api-client` without that chain hit a Class "Composer\Pcre\Preg" not found fatal at runtime when paginating any list endpoint.

This switches the one call site to native `preg_match` and removes the use import.
Trade-off vs. declaring `composer/pcre` as a runtime require is that `Preg::isMatch` throws on PCRE errors while `preg_match(...) === 1` returns false on those errors and silently skips the if-block. For this simple regex against a server-generated Link header I personally feel the dependency is unwarranted.