### PR TITLE
Rename all instances of deprecated param defaultSubrepositoryAccess to defaultSuborganizationAccess

### DIFF
--- a/src/Api/Packages.php
+++ b/src/Api/Packages.php
@@ -60,23 +60,23 @@ class Packages extends AbstractApi
         return $this->get(sprintf('/packages/%s/', $packageIdOrName));
     }
 
-    public function createVcsPackage($url, $credentialId = null, $type = 'vcs', $defaultSubrepositoryAccess = null)
+    public function createVcsPackage($url, $credentialId = null, $type = 'vcs', $defaultSuborganizationAccess = null)
     {
-        $data = new VcsPackageConfig($url, $credentialId, $type, $defaultSubrepositoryAccess);
+        $data = new VcsPackageConfig($url, $credentialId, $type, $defaultSuborganizationAccess);
 
         return $this->post('/packages/', $data->toParameters());
     }
 
-    public function createCustomPackage($customJson, $credentialId = null, $defaultSubrepositoryAccess = null)
+    public function createCustomPackage($customJson, $credentialId = null, $defaultSuborganizationAccess = null)
     {
-        $data = new CustomPackageConfig($customJson, $credentialId, $defaultSubrepositoryAccess);
+        $data = new CustomPackageConfig($customJson, $credentialId, $defaultSuborganizationAccess);
 
         return $this->post('/packages/', $data->toParameters());
     }
 
-    public function createArtifactPackage(array $artifactPackageFileIds, $defaultSubrepositoryAccess = null)
+    public function createArtifactPackage(array $artifactPackageFileIds, $defaultSuborganizationAccess = null)
     {
-        $data = new ArtifactPackageConfig($artifactPackageFileIds, $defaultSubrepositoryAccess);
+        $data = new ArtifactPackageConfig($artifactPackageFileIds, $defaultSuborganizationAccess);
 
         return $this->post('/packages/', $data->toParameters());
     }
@@ -90,16 +90,16 @@ class Packages extends AbstractApi
         return $this->editVcsPackage($packageName, $url, $credentialId);
     }
 
-    public function editVcsPackage($packageIdOrName, $url, $credentialId = null, $type = 'vcs', $defaultSubrepositoryAccess = null)
+    public function editVcsPackage($packageIdOrName, $url, $credentialId = null, $type = 'vcs', $defaultSuborganizationAccess = null)
     {
-        $data = new VcsPackageConfig($url, $credentialId, $type, $defaultSubrepositoryAccess);
+        $data = new VcsPackageConfig($url, $credentialId, $type, $defaultSuborganizationAccess);
 
         return $this->put(sprintf('/packages/%s/', $packageIdOrName), $data->toParameters());
     }
 
-    public function editArtifactPackage($packageIdOrName, array $artifactPackageFileIds, $defaultSubrepositoryAccess = null)
+    public function editArtifactPackage($packageIdOrName, array $artifactPackageFileIds, $defaultSuborganizationAccess = null)
     {
-        $data = new ArtifactPackageConfig($artifactPackageFileIds, $defaultSubrepositoryAccess);
+        $data = new ArtifactPackageConfig($artifactPackageFileIds, $defaultSuborganizationAccess);
 
         return $this->put(sprintf('/packages/%s/', $packageIdOrName), $data->toParameters());
     }
@@ -113,9 +113,9 @@ class Packages extends AbstractApi
         return $this->editCustomPackage($packageName, $customJson, $credentialId);
     }
 
-    public function editCustomPackage($packageIdOrName, $customJson, $credentialId = null, $defaultSubrepositoryAccess = null)
+    public function editCustomPackage($packageIdOrName, $customJson, $credentialId = null, $defaultSuborganizationAccess = null)
     {
-        $data = new CustomPackageConfig($customJson, $credentialId, $defaultSubrepositoryAccess);
+        $data = new CustomPackageConfig($customJson, $credentialId, $defaultSuborganizationAccess);
 
         return $this->put(sprintf('/packages/%s/', $packageIdOrName), $data->toParameters());
     }

--- a/src/Api/Subrepositories/Packages.php
+++ b/src/Api/Subrepositories/Packages.php
@@ -33,30 +33,30 @@ class Packages extends AbstractApi
         return $this->get(sprintf('/subrepositories/%s/packages/%s/', $subrepositoryName, $packageIdOrName));
     }
 
-    public function createVcsPackage($subrepositoryName, $url, $credentialId = null, $type = 'vcs', $defaultSubrepositoryAccess = null)
+    public function createVcsPackage($subrepositoryName, $url, $credentialId = null, $type = 'vcs', $defaultSuborganizationAccess = null)
     {
-        $data = new VcsPackageConfig($url, $credentialId, $type, $defaultSubrepositoryAccess);
+        $data = new VcsPackageConfig($url, $credentialId, $type, $defaultSuborganizationAccess);
 
         return $this->post(sprintf('/subrepositories/%s/packages/', $subrepositoryName), $data->toParameters());
     }
 
-    public function createCustomPackage($subrepositoryName, $customJson, $credentialId = null, $defaultSubrepositoryAccess = null)
+    public function createCustomPackage($subrepositoryName, $customJson, $credentialId = null, $defaultSuborganizationAccess = null)
     {
-        $data = new CustomPackageConfig($customJson, $credentialId, $defaultSubrepositoryAccess);
+        $data = new CustomPackageConfig($customJson, $credentialId, $defaultSuborganizationAccess);
 
         return $this->post(sprintf('/subrepositories/%s/packages/', $subrepositoryName), $data->toParameters());
     }
 
-    public function editVcsPackage($subrepositoryName, $packageIdOrName, $url, $credentialId = null, $type = 'vcs', $defaultSubrepositoryAccess = null)
+    public function editVcsPackage($subrepositoryName, $packageIdOrName, $url, $credentialId = null, $type = 'vcs', $defaultSuborganizationAccess = null)
     {
-        $data = new VcsPackageConfig($url, $credentialId, $type, $defaultSubrepositoryAccess);
+        $data = new VcsPackageConfig($url, $credentialId, $type, $defaultSuborganizationAccess);
 
         return $this->put(sprintf('/subrepositories/%s/packages/%s/', $subrepositoryName, $packageIdOrName), $data->toParameters());
     }
 
-    public function editCustomPackage($subrepositoryName, $packageIdOrName, $customJson, $credentialId = null, $defaultSubrepositoryAccess = null)
+    public function editCustomPackage($subrepositoryName, $packageIdOrName, $customJson, $credentialId = null, $defaultSuborganizationAccess = null)
     {
-        $data = new CustomPackageConfig($customJson, $credentialId, $defaultSubrepositoryAccess);
+        $data = new CustomPackageConfig($customJson, $credentialId, $defaultSuborganizationAccess);
 
         return $this->put(sprintf('/subrepositories/%s/packages/%s/', $subrepositoryName, $packageIdOrName), $data->toParameters());
     }

--- a/src/Payload/ArtifactPackageConfig.php
+++ b/src/Payload/ArtifactPackageConfig.php
@@ -18,20 +18,20 @@ class ArtifactPackageConfig
     /** @var int[] */
     private $artifactPackageFileIds;
     /** @var ?string */
-    private $defaultSubrepositoryAccess;
+    private $defaultSuborganizationAccess;
 
     /**
      * @param int[] $artifactPackageFileIds
-     * @param ?string $defaultSubrepositoryAccess
+     * @param ?string $defaultSuborganizationAccess
      */
-    public function __construct(array $artifactPackageFileIds, $defaultSubrepositoryAccess)
+    public function __construct(array $artifactPackageFileIds, $defaultSuborganizationAccess)
     {
         $this->artifactPackageFileIds = $artifactPackageFileIds;
-        $this->defaultSubrepositoryAccess = $defaultSubrepositoryAccess;
+        $this->defaultSuborganizationAccess = $defaultSuborganizationAccess;
     }
 
     /**
-     * @return array{repoType: string, artifactIds: int[], defaultSubrepositoryAccess?: string}
+     * @return array{repoType: string, artifactIds: int[], defaultSuborganizationAccess?: string}
      */
     public function toParameters(): array
     {
@@ -40,8 +40,8 @@ class ArtifactPackageConfig
             'artifactIds' => $this->artifactPackageFileIds,
         ];
 
-        if ($this->defaultSubrepositoryAccess) {
-            $data['defaultSubrepositoryAccess'] = $this->defaultSubrepositoryAccess;
+        if ($this->defaultSuborganizationAccess) {
+            $data['defaultSuborganizationAccess'] = $this->defaultSuborganizationAccess;
         }
 
         return $data;

--- a/src/Payload/CustomPackageConfig.php
+++ b/src/Payload/CustomPackageConfig.php
@@ -20,14 +20,14 @@ class CustomPackageConfig
     /** @var ?int */
     private $credentialId;
     /** @var ?string */
-    private $defaultSubrepositoryAccess;
+    private $defaultSuborganizationAccess;
 
     /**
      * @param string|array|object $customJson
      * @param ?int $credentialId
-     * @param ?string $defaultSubrepositoryAccess
+     * @param ?string $defaultSuborganizationAccess
      */
-    public function __construct($customJson, $credentialId, $defaultSubrepositoryAccess)
+    public function __construct($customJson, $credentialId, $defaultSuborganizationAccess)
     {
         if (is_array($customJson) || is_object($customJson)) {
             $customJson = json_encode($customJson);
@@ -35,11 +35,11 @@ class CustomPackageConfig
 
         $this->customJson = $customJson;
         $this->credentialId = $credentialId;
-        $this->defaultSubrepositoryAccess = $defaultSubrepositoryAccess;
+        $this->defaultSuborganizationAccess = $defaultSuborganizationAccess;
     }
 
     /**
-     * @return array{repoType: string, repoConfig: string, credentials: ?int, defaultSubrepositoryAccess?: string}
+     * @return array{repoType: string, repoConfig: string, credentials: ?int, defaultSuborganizationAccess?: string}
      */
     public function toParameters(): array
     {
@@ -49,8 +49,8 @@ class CustomPackageConfig
             'credentials' => $this->credentialId,
         ];
 
-        if ($this->defaultSubrepositoryAccess) {
-            $data['defaultSubrepositoryAccess'] = $this->defaultSubrepositoryAccess;
+        if ($this->defaultSuborganizationAccess) {
+            $data['defaultSuborganizationAccess'] = $this->defaultSuborganizationAccess;
         }
 
         return $data;

--- a/src/Payload/VcsPackageConfig.php
+++ b/src/Payload/VcsPackageConfig.php
@@ -22,24 +22,24 @@ class VcsPackageConfig
     /** @var string */
     private $type;
     /** @var ?string */
-    private $defaultSubrepositoryAccess;
+    private $defaultSuborganizationAccess;
 
     /**
      * @param string $url
      * @param ?int $credentialId
      * @param string $type
-     * @param ?string $defaultSubrepositoryAccess
+     * @param ?string $defaultSuborganizationAccess
      */
-    public function __construct($url, $credentialId, $type, $defaultSubrepositoryAccess)
+    public function __construct($url, $credentialId, $type, $defaultSuborganizationAccess)
     {
         $this->url = $url;
         $this->credentialId = $credentialId;
         $this->type = $type;
-        $this->defaultSubrepositoryAccess = $defaultSubrepositoryAccess;
+        $this->defaultSuborganizationAccess = $defaultSuborganizationAccess;
     }
 
     /**
-     * @return array{repoType: string, repoUrl: string, credentials: ?int, defaultSubrepositoryAccess?: string}
+     * @return array{repoType: string, repoUrl: string, credentials: ?int, defaultSuborganizationAccess?: string}
      */
     public function toParameters(): array
     {
@@ -49,8 +49,8 @@ class VcsPackageConfig
             'credentials' => $this->credentialId,
         ];
 
-        if ($this->defaultSubrepositoryAccess) {
-            $data['defaultSubrepositoryAccess'] = $this->defaultSubrepositoryAccess;
+        if ($this->defaultSuborganizationAccess) {
+            $data['defaultSuborganizationAccess'] = $this->defaultSuborganizationAccess;
         }
 
         return $data;

--- a/tests/Api/PackagesTest.php
+++ b/tests/Api/PackagesTest.php
@@ -106,7 +106,7 @@ class PackagesTest extends ApiTestCase
         $this->assertSame($expected, $api->createVcsPackage('localhost'));
     }
 
-    public function testCreateVcsPackageWithDefaultSubrepositoryAccess()
+    public function testCreateVcsPackageWithDefaultSuborganizationAccess()
     {
         $expected = [
             'id' => 'job-id',
@@ -117,7 +117,7 @@ class PackagesTest extends ApiTestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with($this->equalTo('/packages/'), $this->equalTo(['repoType' => 'vcs', 'repoUrl' => 'localhost', 'credentials' => null, 'defaultSubrepositoryAccess' => 'no-access']))
+            ->with($this->equalTo('/packages/'), $this->equalTo(['repoType' => 'vcs', 'repoUrl' => 'localhost', 'credentials' => null, 'defaultSuborganizationAccess' => 'no-access']))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->createVcsPackage('localhost', null, 'vcs', 'no-access'));
@@ -126,7 +126,7 @@ class PackagesTest extends ApiTestCase
     /**
      * @dataProvider customProvider
      */
-    public function testCreateCustomPackage($customJson, $defaultSubrepositoryAccess, array $expectedPayload)
+    public function testCreateCustomPackage($customJson, $defaultSuborganizationAccess, array $expectedPayload)
     {
         $expected = [
             'id' => 'job-id',
@@ -140,7 +140,7 @@ class PackagesTest extends ApiTestCase
             ->with($this->equalTo('/packages/'), $this->equalTo($expectedPayload))
             ->willReturn($expected);
 
-        $this->assertSame($expected, $api->createCustomPackage($customJson, null, $defaultSubrepositoryAccess));
+        $this->assertSame($expected, $api->createCustomPackage($customJson, null, $defaultSuborganizationAccess));
     }
 
     public function customProvider()
@@ -149,11 +149,11 @@ class PackagesTest extends ApiTestCase
             ['{}', null, ['repoType' => 'package', 'repoConfig' => '{}', 'credentials' => null]],
             [new \stdClass(), null, ['repoType' => 'package', 'repoConfig' => '{}', 'credentials' => null]],
             [[], null, ['repoType' => 'package', 'repoConfig' => '[]', 'credentials' => null]],
-            ['{}', 'no-access', ['repoType' => 'package', 'repoConfig' => '{}', 'credentials' => null, 'defaultSubrepositoryAccess' => 'no-access']],
+            ['{}', 'no-access', ['repoType' => 'package', 'repoConfig' => '{}', 'credentials' => null, 'defaultSuborganizationAccess' => 'no-access']],
         ];
     }
 
-    public function testCreateArtifactPackageWithDefaultSubrepositoryAccess()
+    public function testCreateArtifactPackageWithDefaultSuborganizationAccess()
     {
         $expected = [
             'id' => 'job-id',
@@ -164,7 +164,7 @@ class PackagesTest extends ApiTestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with($this->equalTo('/packages/'), $this->equalTo(['repoType' => 'artifact', 'artifactIds' => [42], 'defaultSubrepositoryAccess' => 'no-access']))
+            ->with($this->equalTo('/packages/'), $this->equalTo(['repoType' => 'artifact', 'artifactIds' => [42], 'defaultSuborganizationAccess' => 'no-access']))
             ->willReturn($expected);
 
         $this->assertSame($expected, $api->createArtifactPackage([42], 'no-access'));


### PR DESCRIPTION
In the actual API we have logic to do fallback for `defaultSuborganizationAccess` many places where we observe people passing in the (deprecated) parameter `defaultSubrepositoryAccess`.

One example (actual source not disclosed in this repo):

```
        if (isset($data['defaultSubrepositoryAccess'])) {
            $data['defaultSuborganizationAccess'] = $data['defaultSubrepositoryAccess'];
            unset($data['defaultSubrepositoryAccess']);
        }
```

So the motivation of this PR is to not contribute to using old parameter, and rather get closer to removing fallbacks like the above example :nerd_face: 

The parameter is also deprecated in the API docs: https://packagist.com/docs/api#/Package/createPackage

<img width="638" height="767" alt="image" src="https://github.com/user-attachments/assets/741490ab-7d79-4d3c-b659-3a3911659edd" />


The most important part here is the actual data we pass, but for consistency (people might look at method and variable names before using with curl or custom implementations) all places used are also renamed